### PR TITLE
Update Guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": "~5.0",
+    "guzzlehttp/guzzle": "~6.1",
     "doctrine/couchdb": "dev-trying_generators"
   },
 


### PR DESCRIPTION
Drupal is using guzzle "~6.1" I think couchdb-replicator should be too.
